### PR TITLE
remove warning: unused unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ impl Bitmap {
             .and_then(|bits| bits.checked_add(8 - (bits % 8)))
             .and_then(|rbits| rbits.checked_div(8))
             .and_then(|needed| {
-                let ptr = unsafe {
+                let ptr = {
                     let mut alloc = Vec::<u8>::with_capacity(needed);
                     let ptr = alloc.as_mut_ptr();
                     std::mem::forget(alloc);


### PR DESCRIPTION
Bitmap 1.0.2 makes a warning message with Rust 1.1.

src\lib.rs:39:27: 44:18 warning: unnecessary `unsafe` block, #[warn(unused_unsafe)] on by default
src\lib.rs:39                 let ptr = unsafe {
src\lib.rs:40                     let mut alloc = Vec::<u8>::with_capacity(needed);
src\lib.rs:41                     let ptr = alloc.as_mut_ptr();
src\lib.rs:42                     std::mem::forget(alloc);
src\lib.rs:43                     ptr
src\lib.rs:44                 };
